### PR TITLE
Bridge networking + new env vars

### DIFF
--- a/one-container/README.md
+++ b/one-container/README.md
@@ -37,6 +37,15 @@ REV_SERVER_TARGET=192.168.1.1
 REV_SERVER_CIDR=192.168.0.0/16
 ```
 
+### Using Portainer stacks?
+
+Portainer stacks are a little weird and don't want you to declare your named volumes, so remove this block from the top of the `docker-compose.yaml` file before copy/pasting into Portainer's stack editor:
+
+```yaml
+volumes:
+  etc_pihole-unbound:
+  etc_pihole_dnsmasq-unbound:
+```
 
 ### Running the stack
 

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -8,10 +8,10 @@ services:
     hostname: pihole
     domainname: pihole.local
     ports:
-      - 443/tcp
-      - 53/tcp
-      - 53/udp
-      - 80/tcp
+      - 443:443/tcp
+      - 53:53/tcp
+      - 53:53/udp
+      - 80:80/tcp
       # - 22/tcp # Uncomment to enable SSH
     environment:
       ServerIP: ${ServerIP}
@@ -24,7 +24,6 @@ services:
       DNS1: 127.0.0.1#5335 # Hardcoded to our Unbound server
       DNS2: 127.0.0.1#5335 # Hardcoded to our Unbound server
       DNSSEC: "true" # Enable DNSSEC
-    network_mode: "host"
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
   pihole:
     container_name: pihole
     image: cbcrowe/pihole-unbound:latest
-    hostname: pihole
-    domainname: ${HOSTNAME}
+    hostname: ${HOSTNAME}
+    domainname: ${DOMAIN_NAME}
     ports:
       - 443:443/tcp
       - 53:53/tcp

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     container_name: pihole
     image: cbcrowe/pihole-unbound:latest
     hostname: pihole
-    domainname: pihole.local
+    domainname: ${HOSTNAME}
     ports:
       - 443:443/tcp
       - 53:53/tcp

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -1,5 +1,8 @@
 version: '2'
 
+volumes:
+  etc_pihole-unbound:
+  etc_pihole_dnsmasq-unbound:
 
 services:
   pihole:


### PR DESCRIPTION
- Changing from host networking to bridge networking
- Adding `HOSTNAME` and `DOMAIN_NAME` env vars
- Adding named `volumes` config to docker-compose