### PR TITLE
remove uneeded 1.1.1.1 dns entry

### DIFF
--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
     domainname: ${DOMAIN_NAME}
     dns:
       - 127.0.0.1
-      - 1.1.1.1
     ports:
       - 443:443/tcp
       - 53:53/tcp

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -10,8 +10,6 @@ services:
     image: cbcrowe/pihole-unbound:latest
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
-    dns:
-      - 127.0.0.1
     ports:
       - 443:443/tcp
       - 53:53/tcp


### PR DESCRIPTION
I noticed that the 1.1.1.1 dns entry is set in the docker compose file but it is not used for pihole or unbound in any way so makes sense to remove the entry