### PR TITLE
comment to allow unbound port forwarding

### DIFF
--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       - 53:53/tcp
       - 53:53/udp
       - 80:80/tcp
+      # - 5335:5335/tcp # Uncomment to enable unbound access on local server
+      # - 5335:5335/udp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
       ServerIP: ${ServerIP}

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
       - 53:53/udp
       - 80:80/tcp
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
-      # - 5335:5335/udp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
       ServerIP: ${ServerIP}


### PR DESCRIPTION
Add a comment to allow the unbound service to be exposed to the local server could be useful for troubleshooting purposes or initial set up