### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
       REV_SERVER_CIDR: ${REV_SERVER_CIDR}
       DNS1: 127.0.0.1#5335 # Hardcoded to our Unbound server
-      DNS2: 127.0.0.1#5335 # Hardcoded to our Unbound server
+      DNS2: "no" # this prevents duplicating the same server that's already on DNS1.
       DNSSEC: "true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw


### PR DESCRIPTION
Changed DNS2 to "no". This prevents duplicating DNS1, and leaves PiHole with an empty DNS2 value.