### PR TITLE
Replace deprecated variables

### DIFF
--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       REV_SERVER_TARGET: ${REV_SERVER_TARGET}
       REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
       REV_SERVER_CIDR: ${REV_SERVER_CIDR}
-      PIHOLE_DNS_: 127.0.0.1#5335;127.0.0.1#5335 # Hardcoded to our Unbound server
+      PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
       DNSSEC: "true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -25,8 +25,7 @@ services:
       REV_SERVER_TARGET: ${REV_SERVER_TARGET}
       REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
       REV_SERVER_CIDR: ${REV_SERVER_CIDR}
-      DNS1: 127.0.0.1#5335 # Hardcoded to our Unbound server
-      DNS2: 127.0.0.1#5335 # Hardcoded to our Unbound server
+      PIHOLE_DNS_: 127.0.0.1#5335;127.0.0.1#5335 # Hardcoded to our Unbound server
       DNSSEC: "true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw

--- a/two-container/docker-compose.yaml
+++ b/two-container/docker-compose.yaml
@@ -18,8 +18,7 @@ services:
     environment:
       ServerIP: 192.168.1.5
       WEBPASSWORD: ${WEBPASSWORD}
-      DNS1: 192.168.1.6
-      DNS2: 192.168.1.13
+      PIHOLE_DNS_: 192.168.1.6;192.168.1.13
     volumes:
       - /volume1/docker/pihole-unbound/pihole/volume:/etc/pihole:rw
       - /volume1/docker/pihole-unbound/pihole/config/hosts:/etc/hosts:ro


### PR DESCRIPTION
**DNS1** and **DNS2** environment variables are deprecated as per pi-hole official [documentation](https://github.com/pi-hole/docker-pi-hole#deprecated-environment-variables), **PIHOLE_DNS_** should be used instead.