### PR TITLE
reduce edns-buffer-size to 1232

### DIFF
--- a/one-container/pihole-unbound/99-edns.conf
+++ b/one-container/pihole-unbound/99-edns.conf
@@ -1,0 +1,1 @@
+edns-packet-max=1232

--- a/one-container/pihole-unbound/Dockerfile
+++ b/one-container/pihole-unbound/Dockerfile
@@ -3,6 +3,7 @@ RUN apt update && apt install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf 
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
+COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 COPY start_unbound_and_s6_init.sh start_unbound_and_s6_init.sh
 
 RUN chmod +x start_unbound_and_s6_init.sh

--- a/one-container/pihole-unbound/unbound-pihole.conf
+++ b/one-container/pihole-unbound/unbound-pihole.conf
@@ -34,7 +34,7 @@ server:
 
     # Reduce EDNS reassembly buffer size.
     # Suggested by the unbound man page to reduce fragmentation reassembly problems
-    edns-buffer-size: 1472
+    edns-buffer-size: 1232
 
     # Perform prefetching of close to expired message cache entries
     # This only applies to domains that have been frequently queried


### PR DESCRIPTION
avoids warnings in pihole such as :
Warning in dnsmasq core: reducing DNS packet size for nameserver 127.0.0.1 to 1280
from pihole's doc : https://docs.pi-hole.net/guides/dns/unbound/

I'm not sure if I'm the only one seeing these issues but I'm using the one-container, and keep getting spammed with those, usually around 50-100 warnings per day.