### PR TITLE
Replace FTLCONF_REPLY_ADDR4 with FTLCONF_LOCAL_IPV4

### DIFF
--- a/one-container/README.md
+++ b/one-container/README.md
@@ -18,7 +18,7 @@ First create a `.env` file to substitute variables for your deployment.
 | -------- | ------- | ----- | ---------- |
 | `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `WEBPASSWORD` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `FTLCONF_REPLY_ADDR4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address.
+| `FTLCONF_LOCAL_IPV4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address.
 | `REV_SERVER` | `false` | `<"true"\|"false">` | Enable DNS conditional forwarding for device name resolution |
 | `REV_SERVER_DOMAIN` | unset | Network Domain | If conditional forwarding is enabled, set the domain of the local network router |
 | `REV_SERVER_TARGET` | unset | Router's IP | If conditional forwarding is enabled, set the IP of the local network router |
@@ -28,7 +28,7 @@ First create a `.env` file to substitute variables for your deployment.
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
 ```
-FTLCONF_REPLY_ADDR4=192.168.1.10
+FTLCONF_LOCAL_IPV4=192.168.1.10
 TZ=America/Los_Angeles
 WEBPASSWORD=QWERTY123456asdfASDF
 REV_SERVER=true

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - FTLCONF_REPLY_ADDR4=${FTLCONF_REPLY_ADDR4}
+      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
       - TZ=${TZ:-UTC}
       - WEBPASSWORD=${WEBPASSWORD}
       - WEBTHEME=${WEBTHEME:-default-light}

--- a/two-container/docker-compose.yaml
+++ b/two-container/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - 80/tcp
       - 22/tcp
     environment:
-      - FTLCONF_REPLY_ADDR4=192.168.1.5
+      - FTLCONF_LOCAL_IPV4=192.168.1.5
       - WEBPASSWORD=${WEBPASSWORD}
       - PIHOLE_DNS_=192.168.1.6;192.168.1.13
     volumes:


### PR DESCRIPTION
FTLCONF_REPLY_ADDR4 was deprecated as of [2022.08.1](https://github.com/pi-hole/docker-pi-hole/releases/tag/2022.08.1).  Replaced with FTLCONF_LOCAL_IPV4.
