### PR TITLE
Disable so-rcvbuf custom value

### DIFF
--- a/one-container/pihole-unbound/unbound-pihole.conf
+++ b/one-container/pihole-unbound/unbound-pihole.conf
@@ -44,7 +44,8 @@ server:
     num-threads: 1
 
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
-    so-rcvbuf: 1m
+	# Be aware that if enabled, the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
+    #so-rcvbuf: 1m
 
     # Ensure privacy of local IP ranges
     private-address: 192.168.0.0/16

--- a/one-container/pihole-unbound/unbound-pihole.conf
+++ b/one-container/pihole-unbound/unbound-pihole.conf
@@ -44,7 +44,7 @@ server:
     num-threads: 1
 
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
-    # Be aware that if enabled, the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
+    # Be aware that if enabled (requires CAP_NET_ADMIN or privileged), the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
     #so-rcvbuf: 1m
 
     # Ensure privacy of local IP ranges

--- a/one-container/pihole-unbound/unbound-pihole.conf
+++ b/one-container/pihole-unbound/unbound-pihole.conf
@@ -44,7 +44,7 @@ server:
     num-threads: 1
 
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
-	# Be aware that if enabled, the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
+    # Be aware that if enabled, the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
     #so-rcvbuf: 1m
 
     # Ensure privacy of local IP ranges


### PR DESCRIPTION
Using the default value from the OS is most of the time enough for a normal operation.

This removes an Unbound warning that complains about not having the requested 1m or more for kernel buffering:
> unbound[288:0] warning: so-rcvbuf 1048576 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.rmem_max(linux) or kern.ipc.maxsockbuf(bsd) values.

I would like to thank @MatthewVance for his great [explanation which motivated this PR](https://github.com/MatthewVance/unbound-docker/issues/21#issuecomment-510713050).

Fixes #158 