### PR TITLE
Ability to change server virtual host name

### DIFF
--- a/one-container/README.md
+++ b/one-container/README.md
@@ -24,7 +24,7 @@ First create a `.env` file to substitute variables for your deployment.
 | `REV_SERVER_TARGET` | unset | Router's IP | If conditional forwarding is enabled, set the IP of the local network router |
 | `REV_SERVER_CIDR` | unset | Reverse DNS | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`) |
 | `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light"\|"default-auto"\|"lcars">`| User interface theme to use. |
-| `VIRTUAL_HOST` | `$FTLCONF_LOCAL_IPV4` | `<Custom Hostname>` | `What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address` |
+| `VIRTUAL_HOST` | `$FTLCONF_LOCAL_IPV4` | `<Custom Hostname>` | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address |
 
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 

--- a/one-container/README.md
+++ b/one-container/README.md
@@ -23,7 +23,8 @@ First create a `.env` file to substitute variables for your deployment.
 | `REV_SERVER_DOMAIN` | unset | Network Domain | If conditional forwarding is enabled, set the domain of the local network router |
 | `REV_SERVER_TARGET` | unset | Router's IP | If conditional forwarding is enabled, set the IP of the local network router |
 | `REV_SERVER_CIDR` | unset | Reverse DNS | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`) |
-| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light"\|"default-auto"\|"lcars">`| User interface theme to use.
+| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light"\|"default-auto"\|"lcars">`| User interface theme to use. |
+| `VIRTUAL_HOST` | `$FTLCONF_LOCAL_IPV4` | `<Custom Hostname>` | `What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address` |
 
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
@@ -39,6 +40,7 @@ HOSTNAME=pihole
 DOMAIN_NAME=pihole.local
 PIHOLE_WEBPORT=80
 WEBTHEME=default-light
+VIRTUAL_HOST=pihole.box
 ```
 
 ### Using Portainer stacks?

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - PIHOLE_DNS_=127.0.0.1#5335
       - DNSSEC="true"
       - DNSMASQ_LISTENING=single
+      - VIRTUAL_HOST=${VIRTUAL_HOST}
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw


### PR DESCRIPTION
For my personal setup I had troubles changing default url address using which I could access pihole. As I am new to pihole it took me a while to find a reason of this. Even redirecting requests wasn't working as expected as pihole redirects to /admin/ page only from virtual host name. This pull request might help people with the same issue.