### PR TITLE
Add support for an automatic block/whitelist updater of jacklul

### DIFF
--- a/one-container/pihole-unbound/Dockerfile
+++ b/one-container/pihole-unbound/Dockerfile
@@ -1,12 +1,14 @@
 ARG PIHOLE_VERSION
 FROM pihole/pihole:${PIHOLE_VERSION:-latest}
-RUN apt update && apt install -y unbound
+RUN apt update && apt install -Vy unbound wget php-cli php-sqlite3 php-intl php-curl
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf 
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 RUN mkdir -p /etc/services.d/unbound
 COPY unbound-run /etc/services.d/unbound/run
+
+RUN wget -O - https://raw.githubusercontent.com/jacklul/pihole-updatelists/master/install.sh | bash -s docker
 
 ENTRYPOINT ./s6-init
 


### PR DESCRIPTION
When using remote lists like [this](https://v.firebog.net/hosts/lists.php?type=tick) or [this](https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt) it's a hassle to manually check for changes and update - [the script by jacklul](https://github.com/jacklul/pihole-updatelists) will do that for you! This pull request will add support for this script to the docker container. A lot of people are using it to automatically update their lists and i think it is a valuable addition to the one container solution.