### PR TITLE
ci: smoke-test gate for Renovate releases

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,36 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "build-and-push-pr-image" },
+          { "context": "smoke-test (amd64)" }
+        ]
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/pr-docker-image.yml
+++ b/.github/workflows/pr-docker-image.yml
@@ -36,13 +36,50 @@ jobs:
           echo "Extracted pihole version is: $VERSION"
           echo "PIHOLE_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Compute image ref
+        id: image
+        run: |
+          OWNER=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=ghcr.io/${OWNER}/docker-pihole-unbound:pr${{ github.event.number }}-${{ github.run_number }}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push PR Docker image
         uses: docker/build-push-action@v6.19.2
         with:
           context: docker/
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/docker-pihole-unbound:pr${{ github.event.number }}-${{ github.run_number }}-${{ github.sha }}
+          tags: ${{ steps.image.outputs.ref }}
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+
+  smoke-test:
+    name: smoke-test (amd64)
+    needs: build-and-push-pr-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dig
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends dnsutils
+
+      - name: Pull PR image
+        run: docker pull "${{ needs.build-and-push-pr-image.outputs.image }}"
+
+      - name: Run smoke test
+        run: ./test/smoke-test.sh "${{ needs.build-and-push-pr-image.outputs.image }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Pi-hole + Unbound Docker Image
+
+Drop-in self-hosted Pi-hole + Unbound DNS image for home/SOHO users. Maintained successor of `cbcrowe/pihole-unbound`.
+
+## Stack
+
+- Base: `pihole/pihole` (Alpine); Unbound installed via `apk`
+- Shell entrypoint (`/bin/sh`), s6 init inherited from upstream
+- CI: GitHub Actions multi-arch buildx (`linux/amd64`, `386`, `arm/v6`, `arm/v7`, `arm64`), cosign signing
+- Dep updates: Renovate (`renovate.json`)
+
+## Project Structure
+
+- `docker/` — `Dockerfile`, `custom-entrypoint.sh`, Unbound + lighttpd + dnsmasq configs
+- `example/compose.yaml` — reference Docker Compose for end users
+- `.github/workflows/` — `docker-publish.yml` (main) and `pr-docker-image.yml` (PRs)
+
+## Commands
+
+```bash
+docker build -t pihole-unbound docker/                # Build image from docker/ context
+docker compose -f example/compose.yaml up -d          # Smoke-test bring-up
+docker compose -f example/compose.yaml down -v        # Tear down + drop volumes
+dig @127.0.0.1 -p 53 example.com                      # Verify DNS resolution
+```
+
+## Gotchas
+
+- **Publish workflow path filter**: `.github/workflows/docker-publish.yml` triggers only on changes to `docker/Dockerfile`. Edits to `custom-entrypoint.sh`, `unbound-pihole.conf`, `lighttpd-external.conf`, or `99-edns.conf` will NOT publish a new image until the next Dockerfile bump. Warn the user when editing those files. Never widen the path filter without explicit approval; instead flag the situation and let the user decide.
+- **`docker/unbound-pihole.conf` mirrors the upstream Pi-hole guide** (https://docs.pi-hole.net/guides/unbound/). Treat it as a near-verbatim copy. Do not restructure or "optimize" it; only deviate when the user requests a specific change with a stated reason.
+
+## Out of Scope
+
+- `pihole/pihole:` tag on `docker/Dockerfile:1` — Renovate-managed. Never bump manually; wait for the bot's PR or ask the user to trigger one.
+
+## Approval Required
+
+- `git push` to `main` and any merge into `main`. Feature branches and PRs may proceed without confirmation.
+
+## Testing
+
+No automated test suite. Verify changes by:
+
+1. `docker build docker/` succeeds locally.
+2. Bring up `example/compose.yaml`; `dig @127.0.0.1 -p 53 example.com` returns an answer.
+3. Pi-hole admin UI loads on the configured port.
+
+`pr-docker-image.yml` runs multi-arch builds as a final gate; a green PR build is necessary but not sufficient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Drop-in self-hosted Pi-hole + Unbound DNS image for home/SOHO users. Maintained 
 
 - `docker/` — `Dockerfile`, `custom-entrypoint.sh`, Unbound + lighttpd + dnsmasq configs
 - `example/compose.yaml` — reference Docker Compose for end users
+- `test/smoke-test.sh` — release smoke test (boot, recursive DNS, DNSSEC, admin UI)
 - `.github/workflows/` — `docker-publish.yml` (main) and `pr-docker-image.yml` (PRs)
 
 ## Commands
@@ -39,10 +40,44 @@ dig @127.0.0.1 -p 53 example.com                      # Verify DNS resolution
 
 ## Testing
 
-No automated test suite. Verify changes by:
+Automated smoke test: `test/smoke-test.sh <image-ref>` boots the image, waits for readiness, and asserts:
 
-1. `docker build docker/` succeeds locally.
-2. Bring up `example/compose.yaml`; `dig @127.0.0.1 -p 53 example.com` returns an answer.
-3. Pi-hole admin UI loads on the configured port.
+1. Container in `running` state, no fatal markers in logs.
+2. Unbound listens on `127.0.0.1:5335` inside the container.
+3. Recursive resolution: `dig @127.0.0.1 example.com` and `cloudflare.com` return `NOERROR` with answers.
+4. DNSSEC validating: `dig +dnssec cloudflare.com` returns the `ad` flag.
+5. DNSSEC enforcing: `dnssec-failed.org` returns `SERVFAIL`.
+6. Admin UI at `/admin/` responds 2xx/3xx.
 
-`pr-docker-image.yml` runs multi-arch builds as a final gate; a green PR build is necessary but not sufficient.
+Local run:
+
+```bash
+docker build -t pihole-smoke docker/
+./test/smoke-test.sh pihole-smoke
+```
+
+In CI, `pr-docker-image.yml` runs the script against the just-built PR image (job `smoke-test (amd64)`) after the multi-arch build. Renovate auto-merge for `pihole/pihole` bumps must wait on this check.
+
+## CI gates
+
+`main` is protected via a GitHub Repository Ruleset committed to the repo at `.github/rulesets/main.json`. It requires two status checks before any merge — including Renovate auto-merge of `pihole/pihole` bumps:
+
+- `build-and-push-pr-image` — multi-arch build succeeds.
+- `smoke-test (amd64)` — runtime smoke test passes.
+
+Renovate uses GitHub's native auto-merge (`"platformAutomerge": true` on the `pihole/pihole` rule in `renovate.json`), so a failing smoke test hard-blocks the merge instead of merely delaying Renovate's polling.
+
+Apply / update the ruleset (one-shot, then on every edit to the JSON):
+
+```bash
+# First-time apply
+gh api -X POST repos/:owner/:repo/rulesets \
+  --input .github/rulesets/main.json
+
+# Update after editing the JSON
+RULESET_ID=$(gh api repos/:owner/:repo/rulesets --jq '.[] | select(.name=="main-branch-protection") | .id')
+gh api -X PUT "repos/:owner/:repo/rulesets/${RULESET_ID}" \
+  --input .github/rulesets/main.json
+```
+
+Scope of auto-merge: only `pihole/pihole` Docker tag bumps are auto-merged. All other Renovate-managed dependencies default to `automerge: false` and require manual review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,5 @@ gh api -X PUT "repos/:owner/:repo/rulesets/${RULESET_ID}" \
 ```
 
 Scope of auto-merge: only `pihole/pihole` Docker tag bumps are auto-merged. All other Renovate-managed dependencies default to `automerge: false` and require manual review.
+
+Note: classic branch protection on `main` was intentionally removed in favor of this committed ruleset. Do **not** re-enable classic branch protection — its `required_approving_review_count: 1` clashes with the solo-maintainer model (GitHub forbids self-approval) and deadlocks every PR. The ruleset alone enforces no-deletion, no-force-push, PR-required, and the two required checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
       "matchDatasources": ["docker"],
       "separateMultipleMinor": true,
       "separateMinorPatch": true,
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "matchDepNames": ["pihole/pihole"],
       "matchDatasources": ["docker"],
       "separateMultipleMinor": true,
-      "separateMinorPatch": true
+      "separateMinorPatch": true,
+      "automerge": true
     }
   ]
 }

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Smoke-test a pihole-unbound image: boot it, verify Pi-hole + Unbound
+# answer DNS recursively with DNSSEC validation, then tear down.
+#
+# Usage: ./test/smoke-test.sh <image-ref>
+set -euo pipefail
+IFS=$'\n\t'
+
+IMAGE="${1:?usage: $0 <image-ref>}"
+NAME="pihole-smoke-$$"
+DNS_PORT="${SMOKE_DNS_PORT:-15353}"
+WEB_PORT="${SMOKE_WEB_PORT:-18080}"
+READY_TIMEOUT="${SMOKE_READY_TIMEOUT:-120}"
+
+pass=0
+fail=0
+
+log()  { printf '[smoke] %s\n' "$*"; }
+ok()   { printf 'OK:   %s\n' "$*"; pass=$((pass + 1)); }
+bad()  { printf 'FAIL: %s\n' "$*" >&2; fail=$((fail + 1)); }
+
+cleanup() {
+  local rc=$?
+  if docker inspect "$NAME" >/dev/null 2>&1; then
+    log "container logs (tail 200):"
+    docker logs --tail 200 "$NAME" 2>&1 | sed 's/^/  | /' || true
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+log "starting $IMAGE as $NAME (dns :$DNS_PORT, web :$WEB_PORT)"
+docker run -d --rm \
+  --name "$NAME" \
+  --cap-add=NET_ADMIN \
+  -p "127.0.0.1:${DNS_PORT}:53/udp" \
+  -p "127.0.0.1:${DNS_PORT}:53/tcp" \
+  -p "127.0.0.1:${WEB_PORT}:80/tcp" \
+  -e FTLCONF_webserver_api_password=smoke \
+  -e FTLCONF_dns_upstreams='127.0.0.1#5335' \
+  -e FTLCONF_dns_dnssec='true' \
+  -e FTLCONF_dns_listeningMode=single \
+  -e TZ=UTC \
+  "$IMAGE" >/dev/null
+
+log "waiting for readiness (up to ${READY_TIMEOUT}s)"
+ready=0
+deadline=$(( $(date +%s) + READY_TIMEOUT ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if docker exec "$NAME" pgrep -f 'unbound -d' >/dev/null 2>&1 \
+     && docker exec "$NAME" pgrep pihole-FTL >/dev/null 2>&1 \
+     && dig @127.0.0.1 -p "$DNS_PORT" +time=2 +tries=1 +short cloudflare.com A >/dev/null 2>&1 \
+     && curl -fsS -o /dev/null "http://127.0.0.1:${WEB_PORT}/admin/"; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+
+if [ "$ready" -ne 1 ]; then
+  bad "container did not become ready within ${READY_TIMEOUT}s"
+  exit 1
+fi
+log "ready"
+
+# 1. Container still running
+status=$(docker inspect -f '{{.State.Status}}' "$NAME" 2>/dev/null || echo missing)
+if [ "$status" = "running" ]; then ok "container status=running"
+else bad "container status=$status"; fi
+
+# 2. No fatal markers in logs
+logs=$(docker logs "$NAME" 2>&1 || true)
+if printf '%s' "$logs" | grep -qiE 'ERROR: Unbound failed to start|FTL crashed|fatal:'; then
+  bad "fatal marker in container logs"
+else
+  ok "no fatal markers in logs"
+fi
+
+# 3. Unbound listens on 127.0.0.1:5335 inside the container
+if docker exec "$NAME" sh -c "ss -lnup 2>/dev/null | grep -q '127.0.0.1:5335' \
+     || netstat -lnup 2>/dev/null | grep -q '127.0.0.1:5335'"; then
+  ok "unbound listening on 127.0.0.1:5335"
+else
+  bad "unbound not listening on 127.0.0.1:5335"
+fi
+
+# 4. Recursive resolution via Pi-hole -> Unbound (two names to reduce flake)
+recursion_ok=1
+for host in example.com cloudflare.com; do
+  out=$(dig @127.0.0.1 -p "$DNS_PORT" +time=5 +tries=2 "$host" A 2>&1 || true)
+  if printf '%s' "$out" | grep -q 'status: NOERROR' \
+     && printf '%s' "$out" | grep -qE '^[^;].*\bIN\b.*\bA\b'; then
+    continue
+  fi
+  bad "recursion check failed for $host"
+  printf '%s\n' "$out" | sed 's/^/      /'
+  recursion_ok=0
+done
+[ "$recursion_ok" -eq 1 ] && ok "recursion resolves example.com + cloudflare.com"
+
+# 5. DNSSEC AD flag set on a signed zone
+ad_out=$(dig @127.0.0.1 -p "$DNS_PORT" +dnssec +time=5 +tries=2 cloudflare.com A 2>&1 || true)
+if printf '%s' "$ad_out" | grep -E '^;; flags:' | grep -q ' ad'; then
+  ok "DNSSEC AD flag set on cloudflare.com"
+else
+  bad "DNSSEC AD flag missing on cloudflare.com (Unbound not validating?)"
+  printf '%s\n' "$ad_out" | grep -E '^;; flags:' | sed 's/^/      /' || true
+fi
+
+# 6. DNSSEC failure rejected (SERVFAIL)
+fail_out=$(dig @127.0.0.1 -p "$DNS_PORT" +time=5 +tries=2 dnssec-failed.org A 2>&1 || true)
+if printf '%s' "$fail_out" | grep -q 'status: SERVFAIL'; then
+  ok "DNSSEC validation rejects dnssec-failed.org (SERVFAIL)"
+else
+  bad "dnssec-failed.org did not SERVFAIL — validation chain broken"
+  printf '%s\n' "$fail_out" | grep -E '^;; ->>HEADER|^;; flags' | sed 's/^/      /' || true
+fi
+
+# 7. Admin UI reachable
+code=$(curl -fsS -o /dev/null -w '%{http_code}' "http://127.0.0.1:${WEB_PORT}/admin/" || echo 000)
+case "$code" in
+  2??|3??) ok "admin UI HTTP $code" ;;
+  *)       bad "admin UI HTTP $code" ;;
+esac
+
+printf '\n[smoke] passed=%d failed=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `test/smoke-test.sh`: boots the PR image, verifies Pi-hole resolves recursively via Unbound on `127.0.0.1:5335`, DNSSEC `ad` flag set on signed zones, `dnssec-failed.org` returns `SERVFAIL`, admin UI reachable.
- Adds `smoke-test (amd64)` job to `pr-docker-image.yml`, pulling the just-pushed PR image from GHCR and running the script. ~30s on warm cache.
- Enables `platformAutomerge` on the `pihole/pihole` Renovate rule so auto-merge uses GitHub's native button (strictly honors required checks). Auto-merge scope is unchanged: only `pihole/pihole`.
- Commits `.github/rulesets/main.json` (already applied to the repo, ruleset id `16766953`) requiring `build-and-push-pr-image` and `smoke-test (amd64)` on `main`.
- Updates `AGENTS.md` Testing + CI gates sections.

Also includes two prior local-only commits being brought up to `origin/main`: the earlier `AGENTS.md` add and the Renovate `automerge: true` flip for `pihole/pihole`.

## Test plan

- [ ] `build-and-push-pr-image` job green
- [ ] `smoke-test (amd64)` job green (verifies the gate works on this very PR)
- [ ] Visually confirm GitHub shows both required checks on the PR